### PR TITLE
Do not log logout ('progstop') for non-authenticated users

### DIFF
--- a/log/models.py
+++ b/log/models.py
@@ -96,5 +96,6 @@ user_logged_in.connect(login_handler)
 
 
 def logout_handler(sender, request, **kwargs):
-    Log.objects.create_log('progstop', request)
+    if request.user.is_authenticated():
+        Log.objects.create_log('progstop', request)
 user_logged_out.connect(logout_handler)


### PR DESCRIPTION
This is to prevent a situation found when /accounts/logout/ is reached when already logged out, if lazysignup is not being used. We do not generally allow lazy users to manually logout, so this hopefully changes nothing in a lazysignup-enabled application.
