### PR TITLE
Cope with no user on request

### DIFF
--- a/log/models.py
+++ b/log/models.py
@@ -86,6 +86,8 @@ from django.contrib.auth.signals import user_logged_in, user_logged_out
 
 
 def login_handler(sender, user, request, **kwargs):
+    if not hasattr(request, 'user'):
+        request.user = user
     Log.objects.create_log('progstar', request)
     Log.objects.create_log('VisitNo', request)
     Log.objects.create_log(


### PR DESCRIPTION
The Django test client's fake "login" code ends up calling the login signal
handlers without having set request.user to the user. That was resulting in an
exception from request-log that failed our tests that use login.

The user is passed to the login signal handler anyway, so just set it on the
request object if it's not there already.
