### PR TITLE
Support alternative username field

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 install:
   - pip install coveralls tox-travis
 script: tox

--- a/log/admin.py
+++ b/log/admin.py
@@ -1,4 +1,4 @@
-from django.contrib import admin
+from django.contrib import admin, auth
 
 from .models import Log, RequestLog
 
@@ -7,7 +7,10 @@ class LogAdmin(admin.ModelAdmin):
     list_display = ('user', 'session', 'varname', 'stamp', 'value')
     ordering = ('-stamp',)
     list_filter = ('user',)
-    search_fields = ('user__username', 'varname')
+    search_fields = (
+        'user__{}'.format(auth.get_user_model().USERNAME_FIELD),
+        'varname',
+    )
     save_on_top = True
 admin.site.register(Log, LogAdmin)
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{py,27,34,35}-{trunk,1.10.X,1.9.X},py{py,27,33,34}-1.8.X
+envlist = py36-1.11.X,py{py,27,34,35}-{1.11.X,1.10.X,1.9.X},py{py,27,33,34}-1.8.X
 
 [testenv]
 commands = coverage run --omit=log/tests/** --branch manage.py test
@@ -8,4 +8,5 @@ deps =
   1.8.X: Django>=1.8,<1.9
   1.9.X: Django>=1.9,<1.10
   1.10.X: Django>=1.10,<1.11
+  1.11.X: Django>=1.11,<1.12
   trunk: https://github.com/django/django/archive/master.zip


### PR DESCRIPTION
@orcasgit/orcas-developers Please review. This makes the log admin search work when an alternate `USERNAME_FIELD` is being used, such as `email`